### PR TITLE
update macro to handle non-existent emoji

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ include!(concat!(env!("OUT_DIR"), "/emojis.rs"));
 #[macro_export]
 macro_rules! emoji {
     ($e: expr) => (
-        $crate::EMOJIS.get(&format!(":{}:", $e)[..]).unwrap()
+        $crate::EMOJIS.get(&format!(":{}:", $e)[..]).unwrap_or(&$e);
     )
 }
 

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -29,3 +29,8 @@ fn format_string() {
 fn macros() {
     assert_eq!(emoji!("smile").to_string(), "\u{01F604}");
 }
+
+#[test]
+fn macros_nonexistent() {
+    assert_eq!(emoji!("eat").to_string(), "eat");
+}


### PR DESCRIPTION
- whenever a non-existent (or invalid) emoji string is passed to `emoji!` macro
  it panics and the client code fails.

- this is a rather small change to return the string passed in to `emoji!`
  whenever it is not found in `EMOJIS`.

- includes related test.

- I should note that my knowledge of rust is VERY limited so I cannot say this is 
  the best way to accomplish this, but it's the simplest change I could make that
  would pass the failing test.