### PR TITLE
Updated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,9 @@ license = "MIT"
 build = "build.rs"
 
 [build-dependencies]
-
-phf_codegen = "0.7.10"
+phf_codegen = "0.7.23"
 
 [dependencies]
-
-phf = "0.7.10"
-regex = "0.1.58"
+phf = "0.7.23"
+regex = "1.1" # pattern matching and subs
+lazy_static = "1.2" # regex pattern compilation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,35 @@ macro_rules! emoji {
     )
 }
 
+
+// replaces all emojis with their unicode representation
+pub fn replace_all_emojis(input: &str) -> String{
+
+    // compiles expression only once
+    // and will resuse reference every time
+    lazy_static! {
+        static ref re: Regex = Regex::new(":([a-zA-Z0-9_+-]+):").unwrap();
+    }
+    
+    // replaces all references to emojis
+    let result = re.replace_all(input, |capts: &Captures| {
+        let sym = capts.get(0).unwrap().as_str();
+
+        // returns that string to bind to result
+        // as either the unicode emoji or the string
+        match EMOJIS.get(sym) {
+            Some(e) => format!("{}", e),
+            None    => sym.to_string()
+        }
+    });
+
+    // transfers ownership of string
+    result.into_owned()
+}
+
+
+
+
 /// Newtype used for substituting emoji codes for emoji
 ///
 /// Leaves the notation intact if a corresponding emoji is not found in the
@@ -61,23 +90,4 @@ impl<'a> std::fmt::Display for EmojiFormatter<'a> {
 
         write!(f, "{}", result)
     }
-}
-
-
-#[cfg(test)]
-mod tests{
-    // ease of using names in this file
-    use super::*;
-
-    #[test]
-    fn date_check() {
-        // a simple smile
-        let check = format!("{}", EmojiFormatter("Hello, :smile:!"));
-        assert_eq!(check, "Hello, \u{01F604}!");
-        
-        // a simple hello world
-        let check_world = format!("{}", EmojiFormatter("Hello, :earth_americas:!"));
-        assert_eq!(check_world, "Hello, \u{01F30E}!");
-    }
-
 }


### PR DESCRIPTION
## What I did
I updated the dependencies to their most current versions as well as fixed the breaking changes to `EmojiFormatter` . 

I also added `lazy_static` as a dependency based on the recommendations of [here](https://docs.rs/regex/1.1.0/regex/#example-avoid-compiling-the-same-regex-in-a-loop) from Regex
This should make reusing the same `EmojiFormatter` struct more efficient by not recompiling the same Regex expression every time the struct is used.

Lastly, I added some _very_ basic tests just to ensure that simple substitutions work.


### Why I did it
I wanted to use this in a project I am working on using Rust compiling to Wasm. The older version of regex was not compatible with `wasm32-unknown-unknown` as a compilation target. Theses updates fixed that. My preliminary project compiles!